### PR TITLE
feat: 인텔리빅스 AI Sound Box 장비 연동 및 이벤트 수신

### DIFF
--- a/src/main/kotlin/com/pluxity/aiot/dashboard/DashboardDTOs.kt
+++ b/src/main/kotlin/com/pluxity/aiot/dashboard/DashboardDTOs.kt
@@ -17,6 +17,10 @@ data class SensorTypeStatus(
     val temperatureHumidity: Long,
     val fire: Long,
     val wasteFillLevel: Long,
+    val forestFire: Long,
+    val odorMonitor: Long,
+    val peopleCounter: Long,
+    val compositeAirQuality: Long,
 )
 
 data class SensorStatisticsRaw(
@@ -28,6 +32,10 @@ data class SensorStatisticsRaw(
     val temperatureHumidityCount: Long,
     val fireCount: Long,
     val wasteFillLevelCount: Long,
+    val forestFireCount: Long,
+    val odorMonitorCount: Long,
+    val peopleCounterCount: Long,
+    val compositeAirQualityCount: Long,
 )
 
 fun SensorStatisticsRaw.toSensorSummary() =
@@ -45,5 +53,9 @@ fun SensorStatisticsRaw.toSensorSummary() =
                 temperatureHumidity = temperatureHumidityCount,
                 fire = fireCount,
                 wasteFillLevel = wasteFillLevelCount,
+                forestFire = forestFireCount,
+                odorMonitor = odorMonitorCount,
+                peopleCounter = peopleCounterCount,
+                compositeAirQuality = compositeAirQualityCount,
             ),
     )

--- a/src/main/kotlin/com/pluxity/aiot/data/DataService.kt
+++ b/src/main/kotlin/com/pluxity/aiot/data/DataService.kt
@@ -178,7 +178,7 @@ class DataService(
     ): ListDataResponse {
         val data = getClimateData(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.CLIMATE, climateValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.CLIMATE_SERIES, climateValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 
@@ -190,7 +190,7 @@ class DataService(
     ): ListDataResponse {
         val data = getWasteFillLevel(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.WASTE_FILL_LEVEL, wasteFillLevelValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.WASTE_FILL_LEVEL_SERIES, wasteFillLevelValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 
@@ -202,7 +202,7 @@ class DataService(
     ): ListDataResponse {
         val data = getForestFire(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.FOREST_FIRE, forestFireValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.FOREST_FIRE_SERIES, forestFireValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 
@@ -214,7 +214,7 @@ class DataService(
     ): ListDataResponse {
         val data = getOdorMonitor(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.ODOR_MONITOR, odorMonitorValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.ODOR_MONITOR_SERIES, odorMonitorValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 
@@ -226,7 +226,7 @@ class DataService(
     ): ListDataResponse {
         val data = getPeopleCounter(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.PEOPLE_COUNTER, peopleCounterValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.PEOPLE_COUNTER_SERIES, peopleCounterValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 
@@ -238,7 +238,7 @@ class DataService(
     ): ListDataResponse {
         val data = getCompositeAirQuality(query)
         val bucketList = data.map { convertUtcToKstString(interval, it.requiredTime) }
-        val metrics = data.buildListMetricMap(SensorMetrics.COMPOSITE_AIR_QUALITY, compositeAirQualityValueExtractor)
+        val metrics = data.buildListMetricMap(SensorMetrics.COMPOSITE_AIR_QUALITY_SERIES, compositeAirQualityValueExtractor)
         return createListDataResponse(targetId, interval, timeRange, metrics, bucketList)
     }
 

--- a/src/main/kotlin/com/pluxity/aiot/data/dto/SensorDataDto.kt
+++ b/src/main/kotlin/com/pluxity/aiot/data/dto/SensorDataDto.kt
@@ -110,11 +110,39 @@ inline fun <T> List<T>.buildListMetricMap(
 // 공통 메트릭 정의
 object SensorMetrics {
     val CLIMATE = SensorType.TEMPERATURE_HUMIDITY.deviceProfiles.map { it.toMetricDefinition() }
-    val WASTE_FILL_LEVEL = SensorType.WASTE_FILL_LEVEL.deviceProfiles.map { it.toMetricDefinition() }
-    val FOREST_FIRE = SensorType.FOREST_FIRE.deviceProfiles.map { it.toMetricDefinition() }
-    val ODOR_MONITOR = SensorType.ODOR_MONITOR.deviceProfiles.map { it.toMetricDefinition() }
+
+    /**
+     * 조회 대상은 이벤트 조건 대상(deviceProfiles)보다 넓다.
+     * ContainerModuleId와 HighThreshold는 적재/조회만 하고 조건 평가에는 쓰지 않는다.
+     */
+    val WASTE_FILL_LEVEL =
+        (
+            SensorType.WASTE_FILL_LEVEL.deviceProfiles +
+                listOf(DeviceProfileEnum.CONTAINER_MODULE_ID, DeviceProfileEnum.HIGH_THRESHOLD)
+        ).map { it.toMetricDefinition() }
+    val FOREST_FIRE =
+        (
+            SensorType.FOREST_FIRE.deviceProfiles +
+                listOf(
+                    DeviceProfileEnum.TEMPERATURE,
+                    DeviceProfileEnum.HUMIDITY,
+                    DeviceProfileEnum.CO2,
+                    DeviceProfileEnum.CO,
+                    DeviceProfileEnum.TVOC,
+                    DeviceProfileEnum.FIRE_CAUSE_MASK,
+                )
+        ).map { it.toMetricDefinition() }
+    val ODOR_MONITOR =
+        (
+            SensorType.ODOR_MONITOR.deviceProfiles +
+                listOf(DeviceProfileEnum.TEMPERATURE, DeviceProfileEnum.HUMIDITY)
+        ).map { it.toMetricDefinition() }
     val PEOPLE_COUNTER = SensorType.PEOPLE_COUNTER.deviceProfiles.map { it.toMetricDefinition() }
-    val COMPOSITE_AIR_QUALITY = SensorType.COMPOSITE_AIR_QUALITY.deviceProfiles.map { it.toMetricDefinition() }
+    val COMPOSITE_AIR_QUALITY =
+        (
+            SensorType.COMPOSITE_AIR_QUALITY.deviceProfiles +
+                listOf(DeviceProfileEnum.WIND_DIRECTION, DeviceProfileEnum.LED_LIGHT)
+        ).map { it.toMetricDefinition() }
 }
 
 private fun createDeviceDataResponse(

--- a/src/main/kotlin/com/pluxity/aiot/data/dto/SensorDataDto.kt
+++ b/src/main/kotlin/com/pluxity/aiot/data/dto/SensorDataDto.kt
@@ -143,6 +143,29 @@ object SensorMetrics {
             SensorType.COMPOSITE_AIR_QUALITY.deviceProfiles +
                 listOf(DeviceProfileEnum.WIND_DIRECTION, DeviceProfileEnum.LED_LIGHT)
         ).map { it.toMetricDefinition() }
+
+    /**
+     * 시계열 조회는 버킷마다 mean을 적용하므로, 평균이 값의 의미를 잃는 항목은 제외한다.
+     * Boolean(FireDetection), 비트 마스크(FireCauseMask), 식별 값(ContainerModuleId),
+     * 방위각(WindDirection), 상태값(LED Light)이 여기 해당한다. 현재 값은 최신값 조회로 확인한다.
+     */
+    private val NOT_AVERAGEABLE =
+        setOf(
+            DeviceProfileEnum.CONTAINER_MODULE_ID.fieldKey,
+            DeviceProfileEnum.FOREST_FIRE_DETECTION.fieldKey,
+            DeviceProfileEnum.FIRE_CAUSE_MASK.fieldKey,
+            DeviceProfileEnum.WIND_DIRECTION.fieldKey,
+            DeviceProfileEnum.LED_LIGHT.fieldKey,
+        )
+
+    val CLIMATE_SERIES = CLIMATE.averageable()
+    val WASTE_FILL_LEVEL_SERIES = WASTE_FILL_LEVEL.averageable()
+    val FOREST_FIRE_SERIES = FOREST_FIRE.averageable()
+    val ODOR_MONITOR_SERIES = ODOR_MONITOR.averageable()
+    val PEOPLE_COUNTER_SERIES = PEOPLE_COUNTER.averageable()
+    val COMPOSITE_AIR_QUALITY_SERIES = COMPOSITE_AIR_QUALITY.averageable()
+
+    private fun List<MetricDefinition>.averageable() = filterNot { it.key in NOT_AVERAGEABLE }
 }
 
 private fun createDeviceDataResponse(

--- a/src/main/kotlin/com/pluxity/aiot/data/subscription/processor/SensorDataProcessor.kt
+++ b/src/main/kotlin/com/pluxity/aiot/data/subscription/processor/SensorDataProcessor.kt
@@ -154,12 +154,15 @@ interface SensorDataProcessor {
         // 해당 디바이스 ID로 Feature 찾기 (캐시 사용)
         val feature: Feature = getFeatureFromCacheOrDb(deviceId, featureRepository)
 
-        val matched =
+        // 조건 대상 항목이 하나도 오지 않았다면 판단 근거가 없으므로 상태를 그대로 둔다
+        val evaluable =
             values.mapNotNull { (fieldKey, value) ->
-                // sensorType.deviceProfiles에서 해당 fieldKey의 프로필 찾기
-                val deviceProfile =
-                    sensorType.deviceProfiles.find { it.fieldKey == fieldKey } ?: return@mapNotNull null
+                sensorType.deviceProfiles.find { it.fieldKey == fieldKey }?.let { Triple(fieldKey, value, it) }
+            }
+        if (evaluable.isEmpty()) return
 
+        val matched =
+            evaluable.mapNotNull { (fieldKey, value, deviceProfile) ->
                 eventConditionRepository
                     .findAllByObjectIdAndFieldKey(sensorType.objectId, fieldKey)
                     .filter { it.level != ConditionLevel.NORMAL && it.isActivate }

--- a/src/main/kotlin/com/pluxity/aiot/eds/EdsKeepAliveScheduler.kt
+++ b/src/main/kotlin/com/pluxity/aiot/eds/EdsKeepAliveScheduler.kt
@@ -5,7 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger {}
@@ -16,30 +16,38 @@ class EdsKeepAliveScheduler(
     private val edsClient: EdsClient,
     private val edsProperties: EdsProperties,
 ) {
-    private val scheduler = Executors.newSingleThreadScheduledExecutor()
-    private var task: ScheduledFuture<*>? = null
+    @Volatile
+    private var scheduler: ScheduledExecutorService? = null
 
     fun start() {
         stop()
         val intervalSeconds = edsProperties.keepAliveTimeout / 2
         log.info { "EDS keepAlive 스케줄러 시작 (간격: ${intervalSeconds}초)" }
-        task =
-            scheduler.scheduleAtFixedRate(
-                {
-                    try {
-                        edsClient.keepAlive()
-                    } catch (e: Exception) {
-                        log.error { "EDS keepAlive 스케줄러 실행 중 오류: ${e.message}" }
-                    }
-                },
-                intervalSeconds,
-                intervalSeconds,
-                TimeUnit.SECONDS,
-            )
+        scheduler =
+            newScheduler().apply {
+                scheduleAtFixedRate(
+                    {
+                        try {
+                            edsClient.keepAlive()
+                        } catch (e: Exception) {
+                            log.error { "EDS keepAlive 스케줄러 실행 중 오류: ${e.message}" }
+                        }
+                    },
+                    intervalSeconds,
+                    intervalSeconds,
+                    TimeUnit.SECONDS,
+                )
+            }
     }
 
+    /** 예약 작업뿐 아니라 실행기까지 정리한다. 재시작 시 [start]가 새로 만든다 */
     fun stop() {
-        task?.cancel(false)
-        task = null
+        scheduler?.shutdownNow()
+        scheduler = null
     }
+
+    private fun newScheduler(): ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { runnable ->
+            Thread(runnable, "eds-keepalive").apply { isDaemon = true }
+        }
 }

--- a/src/main/kotlin/com/pluxity/aiot/eds/EdsLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/eds/EdsLifecycle.kt
@@ -1,11 +1,8 @@
 package com.pluxity.aiot.eds
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.pluxity.aiot.global.lifecycle.RetryingLifecycle
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.SmartLifecycle
 import org.springframework.stereotype.Component
-
-private val log = KotlinLogging.logger {}
 
 @Component
 @ConditionalOnProperty("eds.enabled", havingValue = "true")
@@ -14,31 +11,16 @@ class EdsLifecycle(
     private val edsKeepAliveScheduler: EdsKeepAliveScheduler,
     private val edsFacade: EdsFacade,
     private val edsWebSocketClient: EdsWebSocketClient,
-) : SmartLifecycle {
-    private var running = false
-
-    override fun start() {
-        try {
-            log.info { "EDS 연동 시작..." }
-            edsClient.login()
-            edsKeepAliveScheduler.start()
-            edsFacade.sync()
-            edsWebSocketClient.connect()
-            running = true
-            log.info { "EDS 연동 초기화 완료" }
-        } catch (e: Exception) {
-            log.error(e) { "EDS 연동 초기화 실패: ${e.message}" }
-        }
+) : RetryingLifecycle("EDS") {
+    override fun initialize() {
+        edsClient.login()
+        edsKeepAliveScheduler.start()
+        edsFacade.sync()
+        edsWebSocketClient.connect()
     }
 
-    override fun stop() {
-        log.info { "EDS 연동 종료..." }
+    override fun shutdown() {
         edsWebSocketClient.disconnect()
         edsKeepAliveScheduler.stop()
-        running = false
     }
-
-    override fun isRunning(): Boolean = running
-
-    override fun getPhase(): Int = Int.MAX_VALUE - 1
 }

--- a/src/main/kotlin/com/pluxity/aiot/feature/FeatureCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/aiot/feature/FeatureCustomRepositoryImpl.kt
@@ -70,6 +70,30 @@ class FeatureCustomRepositoryImpl(
                                 .like("${SensorType.WASTE_FILL_LEVEL.objectId}%"),
                         ).then(1),
                     ),
+                    count(
+                        caseWhen(
+                            path(Feature::objectId)
+                                .like("${SensorType.FOREST_FIRE.objectId}%"),
+                        ).then(1),
+                    ),
+                    count(
+                        caseWhen(
+                            path(Feature::objectId)
+                                .like("${SensorType.ODOR_MONITOR.objectId}%"),
+                        ).then(1),
+                    ),
+                    count(
+                        caseWhen(
+                            path(Feature::objectId)
+                                .like("${SensorType.PEOPLE_COUNTER.objectId}%"),
+                        ).then(1),
+                    ),
+                    count(
+                        caseWhen(
+                            path(Feature::objectId)
+                                .like("${SensorType.COMPOSITE_AIR_QUALITY.objectId}%"),
+                        ).then(1),
+                    ),
                 ).from(
                     entity(Feature::class),
                     join(Feature::site),

--- a/src/main/kotlin/com/pluxity/aiot/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/constant/ErrorCode.kt
@@ -54,6 +54,9 @@ enum class ErrorCode(
     EDS_LOGIN_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "EDS 로그인 실패: %s"),
     EDS_API_ERROR(HttpStatus.BAD_GATEWAY, "EDS API 호출 실패: %s"),
 
+    MIC_LOGIN_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 마이크 로그인 실패: %s"),
+    MIC_API_ERROR(HttpStatus.BAD_GATEWAY, "AI 마이크 API 호출 실패: %s"),
+
     NOT_FOUND_INVALID_NUMERIC_VALUE(HttpStatus.BAD_REQUEST, "유효한 숫자가 아닙니다."),
     NOT_SUPPORTED_OPERATOR(HttpStatus.BAD_REQUEST, "지원하지 않는 연산자입니다."),
     ;

--- a/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
@@ -3,6 +3,7 @@ package com.pluxity.aiot.global.lifecycle
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.SmartLifecycle
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -23,10 +24,8 @@ abstract class RetryingLifecycle(
     private val initialRetryDelaySeconds: Long = DEFAULT_INITIAL_RETRY_DELAY_SECONDS,
     private val maxRetryDelaySeconds: Long = DEFAULT_MAX_RETRY_DELAY_SECONDS,
 ) : SmartLifecycle {
-    private val scheduler =
-        Executors.newSingleThreadScheduledExecutor { runnable ->
-            Thread(runnable, "$name-lifecycle-retry").apply { isDaemon = true }
-        }
+    @Volatile
+    private var scheduler: ScheduledExecutorService? = null
 
     private val lock = Any()
 
@@ -65,6 +64,10 @@ abstract class RetryingLifecycle(
         synchronized(lock) {
             stopped = false
             active = true
+            scheduler =
+                Executors.newSingleThreadScheduledExecutor { runnable ->
+                    Thread(runnable, "$name-lifecycle-retry").apply { isDaemon = true }
+                }
         }
         log.info { "$name 연동 시작..." }
         attempt(initialRetryDelaySeconds)
@@ -78,6 +81,8 @@ abstract class RetryingLifecycle(
             initialized = false
             retryTask?.cancel(false)
             retryTask = null
+            scheduler?.shutdownNow()
+            scheduler = null
             shutdown()
         }
     }
@@ -97,7 +102,7 @@ abstract class RetryingLifecycle(
                 if (stopped) return
                 log.error(e) { "$name 연동 초기화 실패, ${retryDelaySeconds}초 후 재시도: ${e.message}" }
                 retryTask =
-                    scheduler.schedule(
+                    scheduler?.schedule(
                         { attempt((retryDelaySeconds * 2).coerceAtMost(maxRetryDelaySeconds)) },
                         retryDelaySeconds,
                         TimeUnit.SECONDS,

--- a/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
@@ -1,0 +1,125 @@
+package com.pluxity.aiot.global.lifecycle
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.SmartLifecycle
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 외부 연동의 기동을 담당하되, 초기화가 실패하면 성공할 때까지 백오프를 두고 재시도한다.
+ *
+ * Spring은 [SmartLifecycle.start]를 다시 호출하지 않으므로, 업체 서버가 늦게 뜨거나
+ * 일시적으로 응답하지 않으면 재시작 전까지 연동이 멈춘 채로 남는다. 이를 막기 위한 공통 기반이다.
+ *
+ * @param name 로그에 표시할 연동 이름
+ * @param initialRetryDelaySeconds 첫 재시도까지 대기 시간
+ * @param maxRetryDelaySeconds 재시도 간격 상한
+ */
+abstract class RetryingLifecycle(
+    private val name: String,
+    private val initialRetryDelaySeconds: Long = DEFAULT_INITIAL_RETRY_DELAY_SECONDS,
+    private val maxRetryDelaySeconds: Long = DEFAULT_MAX_RETRY_DELAY_SECONDS,
+) : SmartLifecycle {
+    private val scheduler =
+        Executors.newSingleThreadScheduledExecutor { runnable ->
+            Thread(runnable, "$name-lifecycle-retry").apply { isDaemon = true }
+        }
+
+    private val lock = Any()
+
+    /**
+     * 라이프사이클 활성 여부. 초기화 성공 여부와 별개다.
+     *
+     * DefaultLifecycleProcessor는 isRunning()이 true인 빈에만 stop()을 호출하므로,
+     * 재시도 대기 중에도 true여야 종료 시 예약된 재시도가 취소된다.
+     */
+    @Volatile
+    private var active = false
+
+    @Volatile
+    private var stopped = false
+
+    @Volatile
+    private var initialized = false
+
+    @Volatile
+    private var retryTask: ScheduledFuture<*>? = null
+
+    /** 초기화가 성공해 연동이 실제로 동작 중인지 */
+    val isInitialized: Boolean
+        get() = initialized
+
+    /**
+     * 연동 초기화. 재시도로 여러 번 호출될 수 있으므로 멱등해야 한다.
+     * 실패는 예외로 알린다.
+     */
+    protected abstract fun initialize()
+
+    /** 연동 종료. 초기화가 끝나지 않은 상태에서도 호출될 수 있다 */
+    protected abstract fun shutdown()
+
+    final override fun start() {
+        synchronized(lock) {
+            stopped = false
+            active = true
+        }
+        log.info { "$name 연동 시작..." }
+        attempt(initialRetryDelaySeconds)
+    }
+
+    final override fun stop() {
+        log.info { "$name 연동 종료..." }
+        synchronized(lock) {
+            stopped = true
+            active = false
+            initialized = false
+            retryTask?.cancel(false)
+            retryTask = null
+            shutdown()
+        }
+    }
+
+    final override fun isRunning(): Boolean = active
+
+    override fun getPhase(): Int = Int.MAX_VALUE - 1
+
+    private fun attempt(retryDelaySeconds: Long) {
+        if (stopped) return
+
+        try {
+            initialize()
+        } catch (e: Exception) {
+            synchronized(lock) {
+                initialized = false
+                if (stopped) return
+                log.error(e) { "$name 연동 초기화 실패, ${retryDelaySeconds}초 후 재시도: ${e.message}" }
+                retryTask =
+                    scheduler.schedule(
+                        { attempt((retryDelaySeconds * 2).coerceAtMost(maxRetryDelaySeconds)) },
+                        retryDelaySeconds,
+                        TimeUnit.SECONDS,
+                    )
+            }
+            return
+        }
+
+        synchronized(lock) {
+            if (stopped) {
+                // 초기화 도중 stop()이 호출됐다면, 방금 되살린 자원을 다시 정리한다
+                log.info { "$name 연동 초기화 중 종료 요청, 정리합니다" }
+                shutdown()
+                return
+            }
+            initialized = true
+            log.info { "$name 연동 초기화 완료" }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_INITIAL_RETRY_DELAY_SECONDS = 10L
+        private const val DEFAULT_MAX_RETRY_DELAY_SECONDS = 300L
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycle.kt
@@ -99,7 +99,11 @@ abstract class RetryingLifecycle(
         } catch (e: Exception) {
             synchronized(lock) {
                 initialized = false
-                if (stopped) return
+                if (stopped) {
+                    // 실패하기 전까지 초기화가 되살린 자원이 있을 수 있다
+                    shutdown()
+                    return
+                }
                 log.error(e) { "$name 연동 초기화 실패, ${retryDelaySeconds}초 후 재시도: ${e.message}" }
                 retryTask =
                     scheduler?.schedule(

--- a/src/main/kotlin/com/pluxity/aiot/global/properties/MicProperties.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/properties/MicProperties.kt
@@ -1,0 +1,15 @@
+package com.pluxity.aiot.global.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "mic")
+data class MicProperties(
+    val enabled: Boolean = false,
+    val baseUrl: String = "",
+    val username: String = "",
+    val password: String = "",
+    /** 로그인 응답에 expires_in이 없을 때 사용할 토큰 유효 시간(초) */
+    val tokenTtlFallback: Long = 3600,
+    /** 장비 목록 조회 페이지 크기 */
+    val listPageSize: Int = 100,
+)

--- a/src/main/kotlin/com/pluxity/aiot/mic/Mic.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/Mic.kt
@@ -1,0 +1,104 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.global.entity.BaseEntity
+import com.pluxity.aiot.mic.dto.MicInfo
+import com.pluxity.aiot.mic.dto.MicThreshold
+import com.pluxity.aiot.site.Site
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.PrecisionModel
+
+@Entity
+class Mic(
+    @Column(unique = true, nullable = false)
+    var vendorMicId: String,
+    var name: String? = null,
+    var host: String? = null,
+    var edgeId: String? = null,
+    @Enumerated(EnumType.STRING)
+    var status: MicStatus? = null,
+    var longitude: Double? = null,
+    var latitude: Double? = null,
+    /** 이벤트 카테고리별 감지 기준값. 카테고리가 가변이라 JSON으로 보관한다 */
+    @JdbcTypeCode(SqlTypes.JSON)
+    var thresholds: Map<String, MicThreshold>? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "site_id")
+    var site: Site? = null,
+) : BaseEntity() {
+    @Column(columnDefinition = "geometry(Point, 4326)")
+    var geom: Point? = null
+
+    /**
+     * 벤더 장비 정보로 갱신한다.
+     * @return 실제로 바뀐 값이 있으면 true
+     */
+    fun updateFromVendor(
+        micInfo: MicInfo,
+        site: Site?,
+    ): Boolean {
+        val newStatus = MicStatus.fromValue(micInfo.status)
+        val newLongitude = micInfo.location?.longitude
+        val newLatitude = micInfo.location?.latitude
+
+        val changed =
+            name != micInfo.name ||
+                host != micInfo.host ||
+                edgeId != micInfo.edgeId ||
+                status != newStatus ||
+                thresholds != micInfo.thresholds ||
+                longitude != newLongitude ||
+                latitude != newLatitude ||
+                this.site?.id != site?.id
+
+        name = micInfo.name
+        host = micInfo.host
+        edgeId = micInfo.edgeId
+        status = newStatus
+        thresholds = micInfo.thresholds
+
+        if (newLongitude != null && newLatitude != null) {
+            updateLocationInfo(newLongitude, newLatitude, site)
+        } else {
+            updateLocationEmpty()
+        }
+
+        return changed
+    }
+
+    fun updateLocationInfo(
+        longitude: Double,
+        latitude: Double,
+        site: Site?,
+    ) {
+        this.longitude = longitude
+        this.latitude = latitude
+        this.geom = GEOMETRY_FACTORY.createPoint(Coordinate(longitude, latitude))
+        this.site = site
+    }
+
+    fun updateLocationEmpty() {
+        this.longitude = null
+        this.latitude = null
+        this.geom = null
+        this.site = null
+    }
+
+    fun disconnect() {
+        this.status = MicStatus.DISCONNECTED
+    }
+
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
@@ -1,0 +1,106 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.global.config.WebClientFactory
+import com.pluxity.aiot.global.constant.ErrorCode
+import com.pluxity.aiot.global.exception.CustomException
+import com.pluxity.aiot.global.properties.MicProperties
+import com.pluxity.aiot.mic.dto.MicInfo
+import com.pluxity.aiot.mic.dto.MicLoginRequest
+import com.pluxity.aiot.mic.dto.MicLoginResult
+import com.pluxity.aiot.mic.dto.MicPageResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+private val log = KotlinLogging.logger {}
+
+@Component
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicClient(
+    webClientFactory: WebClientFactory,
+    private val micProperties: MicProperties,
+) {
+    private val client: WebClient = webClientFactory.createClient(micProperties.baseUrl)
+
+    @Volatile
+    private var accessToken: String? = null
+
+    @Volatile
+    private var tokenTtlSeconds: Long = micProperties.tokenTtlFallback
+
+    fun getAccessToken(): String = accessToken ?: throw CustomException(ErrorCode.MIC_LOGIN_FAILED, "토큰 없음")
+
+    /** 토큰 갱신 주기 계산에 사용한다. 벤더 응답에 expires_in이 없으면 설정값으로 대체된다 */
+    fun getTokenTtlSeconds(): Long = tokenTtlSeconds
+
+    fun login() {
+        val result =
+            client
+                .post()
+                .uri("/auth/token")
+                .bodyValue(MicLoginRequest(micProperties.username, micProperties.password))
+                .retrieve()
+                .bodyToMono(MicLoginResult::class.java)
+                .block()
+                ?: throw CustomException(ErrorCode.MIC_LOGIN_FAILED, "응답 없음")
+
+        accessToken = result.accessToken
+        tokenTtlSeconds = result.expiresIn ?: micProperties.tokenTtlFallback
+        log.info { "AI 마이크 로그인 성공 (토큰 유효시간: ${tokenTtlSeconds}초)" }
+    }
+
+    /** 벤더 목록 API가 페이징이라 전체 페이지를 순회해 모은다 */
+    fun getMicList(): List<MicInfo> {
+        val mics = mutableListOf<MicInfo>()
+        var page = 1
+
+        while (true) {
+            val result = getMicPage(page, micProperties.listPageSize)
+            mics += result.results
+            if (page >= result.maxPage || result.results.isEmpty()) break
+            page++
+        }
+
+        log.info { "AI 마이크 목록 조회 완료: ${mics.size}대" }
+        return mics
+    }
+
+    private fun getMicPage(
+        page: Int,
+        size: Int,
+    ): MicPageResult<MicInfo> =
+        withRetryOnUnauthorized {
+            client
+                .get()
+                .uri {
+                    it
+                        .path("/mics")
+                        .queryParam("page", page)
+                        .queryParam("size", size)
+                        .build()
+                }.headers { headers -> headers.setBearerAuth(getAccessToken()) }
+                .retrieve()
+                .bodyToMono(object : ParameterizedTypeReference<MicPageResult<MicInfo>>() {})
+                .block()
+                ?: throw CustomException(ErrorCode.MIC_API_ERROR, "마이크 목록 응답 없음")
+        }
+
+    /**
+     * 토큰 갱신 스케줄러가 만료를 놓친 경우를 대비해, 401이면 재로그인 후 한 번만 다시 호출한다.
+     */
+    private fun <T> withRetryOnUnauthorized(block: () -> T): T =
+        try {
+            block()
+        } catch (e: WebClientResponseException) {
+            if (e.statusCode != HttpStatus.UNAUTHORIZED) {
+                throw CustomException(ErrorCode.MIC_API_ERROR, e.message ?: "알 수 없는 오류")
+            }
+            log.warn { "AI 마이크 API 401, 재로그인 후 재시도" }
+            login()
+            block()
+        }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
@@ -91,6 +91,7 @@ class MicClient(
 
     /**
      * 토큰 갱신 스케줄러가 만료를 놓친 경우를 대비해, 401이면 재로그인 후 한 번만 다시 호출한다.
+     * 재로그인과 재시도에서 난 오류도 도메인 예외로 변환해, 일반 500으로 새어 나가지 않게 한다.
      */
     private fun <T> withRetryOnUnauthorized(block: () -> T): T =
         try {
@@ -100,7 +101,20 @@ class MicClient(
                 throw CustomException(ErrorCode.MIC_API_ERROR, e.message ?: "알 수 없는 오류")
             }
             log.warn { "AI 마이크 API 401, 재로그인 후 재시도" }
-            login()
-            block()
+            retryAfterLogin(block)
         }
+
+    private fun <T> retryAfterLogin(block: () -> T): T {
+        try {
+            login()
+        } catch (e: Exception) {
+            throw CustomException(ErrorCode.MIC_LOGIN_FAILED, e.message ?: "알 수 없는 오류")
+        }
+
+        return try {
+            block()
+        } catch (e: Exception) {
+            throw CustomException(ErrorCode.MIC_API_ERROR, e.message ?: "알 수 없는 오류")
+        }
+    }
 }

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicController.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicController.kt
@@ -1,0 +1,78 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.global.response.DataResponseBody
+import com.pluxity.aiot.global.response.ErrorResponseBody
+import com.pluxity.aiot.global.response.PageResponse
+import com.pluxity.aiot.mic.dto.MicEventResponse
+import com.pluxity.aiot.mic.dto.MicResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/mics")
+@Tag(name = "AI Mic Controller", description = "AI 마이크(Sound Box) 관리 API")
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicController(
+    private val micService: MicService,
+    private val micEventService: MicEventService,
+    private val micFacade: MicFacade,
+) {
+    @Operation(summary = "AI 마이크 목록 조회", description = "연동된 AI 마이크 장비 목록을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "마이크 목록 조회 성공"),
+        ],
+    )
+    @GetMapping
+    fun getMics(): ResponseEntity<DataResponseBody<List<MicResponse>>> = ResponseEntity.ok(DataResponseBody(micService.findAll()))
+
+    @Operation(summary = "AI 마이크 이벤트 목록 조회", description = "AI 마이크 이벤트 목록을 페이징하여 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "이벤트 목록 조회 성공"),
+        ],
+    )
+    @GetMapping("/events")
+    fun getEvents(
+        @Parameter(description = "페이지 번호 (1부터 시작)") @RequestParam(defaultValue = "1") page: Int,
+        @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "9999") size: Int,
+        @Parameter(description = "업체 장비 식별자") @RequestParam(required = false) micId: String?,
+        @Parameter(description = "조회 시작일시 (yyyyMMddHHmmss)") @RequestParam(required = false) from: String?,
+        @Parameter(description = "조회 종료일시 (yyyyMMddHHmmss)") @RequestParam(required = false) to: String?,
+    ): ResponseEntity<DataResponseBody<PageResponse<MicEventResponse>>> =
+        ResponseEntity.ok(DataResponseBody(micEventService.findAll(page, size, micId, from, to)))
+
+    @Operation(summary = "AI 마이크 동기화", description = "업체 서버의 마이크 목록을 조회하여 마이크 테이블과 동기화합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "마이크 동기화 성공"),
+            ApiResponse(
+                responseCode = "502",
+                description = "업체 API 호출 실패",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @PostMapping("/sync")
+    fun sync(): ResponseEntity<Void> {
+        micFacade.sync()
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicEvent.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicEvent.kt
@@ -1,0 +1,34 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.LocalDateTime
+
+@Entity
+@Table(indexes = [Index(columnList = "micId"), Index(columnList = "occurredAt")])
+class MicEvent(
+    /** 벤더가 발급한 이벤트 식별자 */
+    @Column(unique = true, nullable = false)
+    var eventId: String,
+    @Column(nullable = false)
+    var micId: String,
+    var micName: String? = null,
+    var labelId: String? = null,
+    var labelNameKo: String? = null,
+    var labelNameEn: String? = null,
+    var confidence: Double? = null,
+    var latitude: Double? = null,
+    var longitude: Double? = null,
+    /** 이벤트 구간의 소음 측정 원본 배열 */
+    @JdbcTypeCode(SqlTypes.JSON)
+    var noises: List<Double>? = null,
+    var maxNoise: Double? = null,
+    var avgNoise: Double? = null,
+    @Column(nullable = false)
+    var occurredAt: LocalDateTime,
+) : BaseEntity()

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicEventCustomRepository.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicEventCustomRepository.kt
@@ -1,0 +1,13 @@
+package com.pluxity.aiot.mic
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface MicEventCustomRepository {
+    fun findAllByFilter(
+        pageable: Pageable,
+        micId: String?,
+        from: String?,
+        to: String?,
+    ): Page<MicEvent>
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicEventCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicEventCustomRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.pluxity.aiot.mic
+
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import com.pluxity.aiot.global.utils.DateTimeUtils
+import com.pluxity.aiot.global.utils.findPageNotNull
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class MicEventCustomRepositoryImpl(
+    private val kotlinJdslJpqlExecutor: KotlinJdslJpqlExecutor,
+) : MicEventCustomRepository {
+    override fun findAllByFilter(
+        pageable: Pageable,
+        micId: String?,
+        from: String?,
+        to: String?,
+    ): Page<MicEvent> =
+        kotlinJdslJpqlExecutor
+            .findPageNotNull(pageable) {
+                select(entity(MicEvent::class))
+                    .from(entity(MicEvent::class))
+                    .where(
+                        and(
+                            micId?.let { path(MicEvent::micId).equal(it) },
+                            from?.let {
+                                path(MicEvent::occurredAt).greaterThanOrEqualTo(
+                                    DateTimeUtils.parseCompactDateTime(it),
+                                )
+                            },
+                            to?.let {
+                                path(MicEvent::occurredAt).lessThanOrEqualTo(
+                                    DateTimeUtils.parseCompactDateTime(it),
+                                )
+                            },
+                        ),
+                    ).orderBy(
+                        path(MicEvent::occurredAt).desc(),
+                    )
+            }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicEventRepository.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicEventRepository.kt
@@ -1,0 +1,9 @@
+package com.pluxity.aiot.mic
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MicEventRepository :
+    JpaRepository<MicEvent, Long>,
+    MicEventCustomRepository {
+    fun existsByEventId(eventId: String): Boolean
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicEventService.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicEventService.kt
@@ -1,0 +1,84 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.global.response.PageResponse
+import com.pluxity.aiot.global.response.toPageResponse
+import com.pluxity.aiot.mic.dto.MicEventData
+import com.pluxity.aiot.mic.dto.MicEventResponse
+import com.pluxity.aiot.mic.dto.toResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+private val log = KotlinLogging.logger {}
+
+@Service
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+@Transactional(readOnly = true)
+class MicEventService(
+    private val micEventRepository: MicEventRepository,
+) {
+    fun findAll(
+        page: Int,
+        size: Int,
+        micId: String?,
+        from: String?,
+        to: String?,
+    ): PageResponse<MicEventResponse> {
+        val pageable = PageRequest.of(page - 1, size)
+        return micEventRepository.findAllByFilter(pageable, micId, from, to).toPageResponse { it.toResponse() }
+    }
+
+    @Transactional
+    fun saveEvent(eventData: MicEventData) {
+        val micId = eventData.mic?.id
+        if (micId == null) {
+            log.warn { "AI 마이크 이벤트에 마이크 정보가 없어 저장하지 않습니다: eventId=${eventData.id}" }
+            return
+        }
+
+        if (micEventRepository.existsByEventId(eventData.id)) {
+            log.debug { "이미 저장된 AI 마이크 이벤트입니다: eventId=${eventData.id}" }
+            return
+        }
+
+        val noises = eventData.noises
+
+        micEventRepository.save(
+            MicEvent(
+                eventId = eventData.id,
+                micId = micId,
+                micName = eventData.mic.name,
+                labelId = eventData.label?.id,
+                labelNameKo = eventData.label?.name?.ko,
+                labelNameEn = eventData.label?.name?.en,
+                confidence = eventData.confidence,
+                latitude = eventData.mic.location?.latitude,
+                longitude = eventData.mic.location?.longitude,
+                noises = noises,
+                maxNoise = noises?.maxOrNull(),
+                avgNoise = noises?.takeIf { it.isNotEmpty() }?.average(),
+                occurredAt = parseOccurredAt(eventData.createdAt),
+            ),
+        )
+    }
+
+    /** 벤더는 created_at을 UTC ISO-8601로 준다. 다른 시각 컬럼과 맞추기 위해 KST로 변환한다 */
+    private fun parseOccurredAt(createdAt: String?): LocalDateTime {
+        if (createdAt == null) return LocalDateTime.now()
+        return try {
+            OffsetDateTime.parse(createdAt).atZoneSameInstant(KST).toLocalDateTime()
+        } catch (e: Exception) {
+            log.warn { "AI 마이크 이벤트 created_at 파싱 실패, 수신 시각으로 대체합니다: $createdAt (${e.message})" }
+            LocalDateTime.now()
+        }
+    }
+
+    companion object {
+        private val KST = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicFacade.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicFacade.kt
@@ -1,21 +1,19 @@
 package com.pluxity.aiot.mic
 
-import com.pluxity.aiot.mic.dto.MicEventData
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+/**
+ * 업체 장비 목록 조회(HTTP)와 반영(트랜잭션)을 분리해 조합한다.
+ * 목록 조회가 MicService의 트랜잭션 밖에서 끝나도록 하는 것이 이 클래스의 존재 이유다.
+ */
 @Component
 @ConditionalOnProperty("mic.enabled", havingValue = "true")
 class MicFacade(
     private val micClient: MicClient,
     private val micService: MicService,
-    private val micEventService: MicEventService,
 ) {
     fun sync() {
         micService.sync(micClient.getMicList())
-    }
-
-    fun processEvent(eventData: MicEventData) {
-        micEventService.saveEvent(eventData)
     }
 }

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicFacade.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicFacade.kt
@@ -1,0 +1,21 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.mic.dto.MicEventData
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicFacade(
+    private val micClient: MicClient,
+    private val micService: MicService,
+    private val micEventService: MicEventService,
+) {
+    fun sync() {
+        micService.sync(micClient.getMicList())
+    }
+
+    fun processEvent(eventData: MicEventData) {
+        micEventService.saveEvent(eventData)
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicLifecycle.kt
@@ -1,0 +1,44 @@
+package com.pluxity.aiot.mic
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.SmartLifecycle
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicLifecycle(
+    private val micClient: MicClient,
+    private val micTokenScheduler: MicTokenScheduler,
+    private val micFacade: MicFacade,
+    private val micWebSocketClient: MicWebSocketClient,
+) : SmartLifecycle {
+    private var running = false
+
+    override fun start() {
+        try {
+            log.info { "AI 마이크 연동 시작..." }
+            micClient.login()
+            micTokenScheduler.start()
+            micFacade.sync()
+            micWebSocketClient.connect()
+            running = true
+            log.info { "AI 마이크 연동 초기화 완료" }
+        } catch (e: Exception) {
+            log.error(e) { "AI 마이크 연동 초기화 실패: ${e.message}" }
+        }
+    }
+
+    override fun stop() {
+        log.info { "AI 마이크 연동 종료..." }
+        micWebSocketClient.disconnect()
+        micTokenScheduler.stop()
+        running = false
+    }
+
+    override fun isRunning(): Boolean = running
+
+    override fun getPhase(): Int = Int.MAX_VALUE - 1
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicLifecycle.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicLifecycle.kt
@@ -1,11 +1,8 @@
 package com.pluxity.aiot.mic
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import com.pluxity.aiot.global.lifecycle.RetryingLifecycle
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.SmartLifecycle
 import org.springframework.stereotype.Component
-
-private val log = KotlinLogging.logger {}
 
 @Component
 @ConditionalOnProperty("mic.enabled", havingValue = "true")
@@ -14,31 +11,16 @@ class MicLifecycle(
     private val micTokenScheduler: MicTokenScheduler,
     private val micFacade: MicFacade,
     private val micWebSocketClient: MicWebSocketClient,
-) : SmartLifecycle {
-    private var running = false
-
-    override fun start() {
-        try {
-            log.info { "AI 마이크 연동 시작..." }
-            micClient.login()
-            micTokenScheduler.start()
-            micFacade.sync()
-            micWebSocketClient.connect()
-            running = true
-            log.info { "AI 마이크 연동 초기화 완료" }
-        } catch (e: Exception) {
-            log.error(e) { "AI 마이크 연동 초기화 실패: ${e.message}" }
-        }
+) : RetryingLifecycle("AI 마이크") {
+    override fun initialize() {
+        micClient.login()
+        micTokenScheduler.start()
+        micFacade.sync()
+        micWebSocketClient.connect()
     }
 
-    override fun stop() {
-        log.info { "AI 마이크 연동 종료..." }
+    override fun shutdown() {
         micWebSocketClient.disconnect()
         micTokenScheduler.stop()
-        running = false
     }
-
-    override fun isRunning(): Boolean = running
-
-    override fun getPhase(): Int = Int.MAX_VALUE - 1
 }

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicRepository.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicRepository.kt
@@ -1,0 +1,9 @@
+package com.pluxity.aiot.mic
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface MicRepository : JpaRepository<Mic, Long> {
+    @Query("select m from Mic m left join fetch m.site")
+    fun findAllWithSite(): List<Mic>
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicService.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicService.kt
@@ -1,0 +1,69 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.mic.dto.MicInfo
+import com.pluxity.aiot.mic.dto.MicResponse
+import com.pluxity.aiot.mic.dto.toResponse
+import com.pluxity.aiot.site.SiteRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+@Service
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+@Transactional(readOnly = true)
+class MicService(
+    private val micRepository: MicRepository,
+    private val siteRepository: SiteRepository,
+) {
+    fun findAll(): List<MicResponse> = micRepository.findAllWithSite().map { it.toResponse() }
+
+    @Transactional
+    fun sync(micInfos: List<MicInfo>) {
+        val vendorMicIds = micInfos.map { it.id }.toSet()
+        val existingMics = micRepository.findAllWithSite()
+        val existingMap = existingMics.associateBy { it.vendorMicId }
+
+        var created = 0
+        var updated = 0
+        var disconnected = 0
+
+        for (micInfo in micInfos) {
+            val existing = existingMap[micInfo.id]
+            if (existing != null) {
+                if (existing.updateFromVendor(micInfo, findSite(micInfo))) updated++
+            } else {
+                createMic(micInfo)
+                created++
+            }
+        }
+
+        for (mic in existingMics) {
+            if (mic.vendorMicId !in vendorMicIds && mic.status != MicStatus.DISCONNECTED) {
+                mic.disconnect()
+                disconnected++
+            }
+        }
+
+        log.info { "AI 마이크 동기화 완료: 신규=$created, 업데이트=$updated, 미연동처리=$disconnected" }
+    }
+
+    private fun createMic(micInfo: MicInfo) {
+        val mic = Mic(vendorMicId = micInfo.id)
+        mic.updateFromVendor(micInfo, findSite(micInfo))
+        micRepository.save(mic)
+    }
+
+    private fun findSite(micInfo: MicInfo) =
+        micInfo.location?.let { location ->
+            val longitude = location.longitude
+            val latitude = location.latitude
+            if (longitude != null && latitude != null) {
+                siteRepository.findFirstByPointInPolygon(longitude, latitude)
+            } else {
+                null
+            }
+        }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicStatus.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicStatus.kt
@@ -1,0 +1,14 @@
+package com.pluxity.aiot.mic
+
+enum class MicStatus {
+    ACTIVE,
+    INACTIVE,
+
+    /** 벤더 장비 목록에서 사라진 상태 */
+    DISCONNECTED,
+    ;
+
+    companion object {
+        fun fromValue(value: String?): MicStatus? = entries.find { it.name.equals(value, ignoreCase = true) }
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicTokenScheduler.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicTokenScheduler.kt
@@ -4,7 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger {}
@@ -18,34 +18,40 @@ private val log = KotlinLogging.logger {}
 class MicTokenScheduler(
     private val micClient: MicClient,
 ) {
-    private val scheduler = Executors.newSingleThreadScheduledExecutor()
-
     @Volatile
-    private var task: ScheduledFuture<*>? = null
+    private var scheduler: ScheduledExecutorService? = null
 
     fun start() {
         stop()
         val intervalSeconds = (micClient.getTokenTtlSeconds() / 2).coerceAtLeast(MIN_INTERVAL_SECONDS)
         log.info { "AI 마이크 토큰 갱신 스케줄러 시작 (간격: ${intervalSeconds}초)" }
-        task =
-            scheduler.scheduleAtFixedRate(
-                {
-                    try {
-                        micClient.login()
-                    } catch (e: Exception) {
-                        log.error { "AI 마이크 토큰 갱신 실패: ${e.message}" }
-                    }
-                },
-                intervalSeconds,
-                intervalSeconds,
-                TimeUnit.SECONDS,
-            )
+        scheduler =
+            newScheduler().apply {
+                scheduleAtFixedRate(
+                    {
+                        try {
+                            micClient.login()
+                        } catch (e: Exception) {
+                            log.error { "AI 마이크 토큰 갱신 실패: ${e.message}" }
+                        }
+                    },
+                    intervalSeconds,
+                    intervalSeconds,
+                    TimeUnit.SECONDS,
+                )
+            }
     }
 
+    /** 예약 작업뿐 아니라 실행기까지 정리한다. 재시작 시 [start]가 새로 만든다 */
     fun stop() {
-        task?.cancel(false)
-        task = null
+        scheduler?.shutdownNow()
+        scheduler = null
     }
+
+    private fun newScheduler(): ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { runnable ->
+            Thread(runnable, "mic-token-refresh").apply { isDaemon = true }
+        }
 
     companion object {
         private const val MIN_INTERVAL_SECONDS = 60L

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicTokenScheduler.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicTokenScheduler.kt
@@ -1,0 +1,53 @@
+package com.pluxity.aiot.mic
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 벤더에 토큰 갱신 엔드포인트가 없어, 만료 전에 재로그인해 토큰을 새로 받는다.
+ * 재로그인은 accessToken을 갱신하므로 단일 스레드로 직렬화한다.
+ */
+@Component
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicTokenScheduler(
+    private val micClient: MicClient,
+) {
+    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+
+    @Volatile
+    private var task: ScheduledFuture<*>? = null
+
+    fun start() {
+        stop()
+        val intervalSeconds = (micClient.getTokenTtlSeconds() / 2).coerceAtLeast(MIN_INTERVAL_SECONDS)
+        log.info { "AI 마이크 토큰 갱신 스케줄러 시작 (간격: ${intervalSeconds}초)" }
+        task =
+            scheduler.scheduleAtFixedRate(
+                {
+                    try {
+                        micClient.login()
+                    } catch (e: Exception) {
+                        log.error { "AI 마이크 토큰 갱신 실패: ${e.message}" }
+                    }
+                },
+                intervalSeconds,
+                intervalSeconds,
+                TimeUnit.SECONDS,
+            )
+    }
+
+    fun stop() {
+        task?.cancel(false)
+        task = null
+    }
+
+    companion object {
+        private const val MIN_INTERVAL_SECONDS = 60L
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
@@ -1,0 +1,97 @@
+package com.pluxity.aiot.mic
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.pluxity.aiot.global.properties.MicProperties
+import com.pluxity.aiot.mic.dto.MicEventData
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.socket.WebSocketMessage
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
+import reactor.core.Disposable
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.netty.http.client.HttpClient
+import reactor.util.retry.Retry
+import java.net.URI
+import java.time.Duration
+
+private val log = KotlinLogging.logger {}
+
+@Component
+@ConditionalOnProperty("mic.enabled", havingValue = "true")
+class MicWebSocketClient(
+    private val micClient: MicClient,
+    private val micProperties: MicProperties,
+    private val objectMapper: ObjectMapper,
+    private val micFacade: MicFacade,
+) {
+    @Volatile
+    private var disposable: Disposable? = null
+
+    @Volatile
+    private var stopped = false
+
+    fun connect() {
+        disconnect()
+        stopped = false
+
+        val client = ReactorNettyWebSocketClient(HttpClient.create())
+
+        disposable =
+            // Mono.defer로 감싸야 재연결 시점에 갱신된 토큰을 다시 읽는다
+            Mono
+                .defer {
+                    client.execute(buildUri(), buildHeaders()) { session ->
+                        log.info { "AI 마이크 WebSocket 연결 성공" }
+
+                        session
+                            .receive()
+                            .filter { it.type == WebSocketMessage.Type.TEXT }
+                            .map { it.payloadAsText }
+                            .publishOn(Schedulers.boundedElastic())
+                            .doOnNext { handleMessage(it) }
+                            .doOnError { e -> log.error(e) { "AI 마이크 WebSocket 오류" } }
+                            .doOnComplete { log.info { "AI 마이크 WebSocket 연결 종료" } }
+                            .then()
+                    }
+                }.doOnSuccess { if (!stopped) log.warn { "AI 마이크 WebSocket 연결 정상 종료, 재연결 예정" } }
+                .repeatWhen { it.delayElements(Duration.ofSeconds(5)).takeWhile { !stopped } }
+                .retryWhen(
+                    Retry
+                        .backoff(Long.MAX_VALUE, Duration.ofSeconds(5))
+                        .maxBackoff(Duration.ofMinutes(2))
+                        .filter { !stopped }
+                        .doBeforeRetry { log.info { "AI 마이크 WebSocket 재연결 시도 (${it.totalRetries() + 1}회)" } },
+                ).subscribe()
+    }
+
+    fun disconnect() {
+        stopped = true
+        disposable?.dispose()
+        disposable = null
+    }
+
+    private fun buildUri(): URI = URI(micProperties.baseUrl.replaceFirst(HTTP_SCHEME_REGEX, "ws") + WS_EVENTS_PATH)
+
+    private fun buildHeaders(): HttpHeaders =
+        HttpHeaders().apply {
+            setBearerAuth(micClient.getAccessToken())
+        }
+
+    private fun handleMessage(json: String) {
+        try {
+            val event = objectMapper.readValue(json, MicEventData::class.java)
+            log.info { "AI 마이크 이벤트: id=${event.id}, mic=${event.mic?.id}, label=${event.label?.id}" }
+            micFacade.processEvent(event)
+        } catch (e: Exception) {
+            log.error(e) { "AI 마이크 메시지 처리 오류: $json" }
+        }
+    }
+
+    companion object {
+        private val HTTP_SCHEME_REGEX = Regex("^http")
+        private const val WS_EVENTS_PATH = "/ws/events"
+    }
+}

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
@@ -25,7 +25,7 @@ class MicWebSocketClient(
     private val micClient: MicClient,
     private val micProperties: MicProperties,
     private val objectMapper: ObjectMapper,
-    private val micFacade: MicFacade,
+    private val micEventService: MicEventService,
 ) {
     @Volatile
     private var disposable: Disposable? = null
@@ -84,7 +84,7 @@ class MicWebSocketClient(
         try {
             val event = objectMapper.readValue(json, MicEventData::class.java)
             log.info { "AI 마이크 이벤트: id=${event.id}, mic=${event.mic?.id}, label=${event.label?.id}" }
-            micFacade.processEvent(event)
+            micEventService.saveEvent(event)
         } catch (e: Exception) {
             log.error(e) { "AI 마이크 메시지 처리 오류: $json" }
         }

--- a/src/main/kotlin/com/pluxity/aiot/mic/dto/MicAuthDto.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/dto/MicAuthDto.kt
@@ -1,0 +1,19 @@
+package com.pluxity.aiot.mic.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class MicLoginRequest(
+    val username: String,
+    val password: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicLoginResult(
+    @field:JsonProperty("access_token")
+    val accessToken: String,
+    @field:JsonProperty("token_type")
+    val tokenType: String? = null,
+    @field:JsonProperty("expires_in")
+    val expiresIn: Long? = null,
+)

--- a/src/main/kotlin/com/pluxity/aiot/mic/dto/MicDto.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/dto/MicDto.kt
@@ -1,0 +1,41 @@
+package com.pluxity.aiot.mic.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicPageResult<T>(
+    val page: Int = 1,
+    val size: Int = 0,
+    @field:JsonProperty("total_cnt")
+    val totalCount: Int = 0,
+    @field:JsonProperty("max_page")
+    val maxPage: Int = 0,
+    val results: List<T> = emptyList(),
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicInfo(
+    val id: String,
+    val name: String? = null,
+    val host: String? = null,
+    @field:JsonProperty("edge_id")
+    val edgeId: String? = null,
+    val status: String? = null,
+    /** 키가 이벤트 카테고리로 가변이라 Map으로 받는다 */
+    val thresholds: Map<String, MicThreshold>? = null,
+    val location: MicLocation? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicThreshold(
+    @field:JsonProperty("sound_level_ge")
+    val soundLevelGe: Double? = null,
+    val confidence: Double? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicLocation(
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+)

--- a/src/main/kotlin/com/pluxity/aiot/mic/dto/MicEventDto.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/dto/MicEventDto.kt
@@ -1,0 +1,34 @@
+package com.pluxity.aiot.mic.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicEventData(
+    val id: String,
+    val label: MicEventLabel? = null,
+    val confidence: Double? = null,
+    val mic: MicEventSource? = null,
+    @field:JsonProperty("created_at")
+    val createdAt: String? = null,
+    val noises: List<Double>? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicEventLabel(
+    val id: String? = null,
+    val name: MicEventLabelName? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicEventLabelName(
+    val ko: String? = null,
+    val en: String? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class MicEventSource(
+    val id: String,
+    val name: String? = null,
+    val location: MicLocation? = null,
+)

--- a/src/main/kotlin/com/pluxity/aiot/mic/dto/MicResponse.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/dto/MicResponse.kt
@@ -1,0 +1,97 @@
+package com.pluxity.aiot.mic.dto
+
+import com.pluxity.aiot.mic.Mic
+import com.pluxity.aiot.mic.MicEvent
+import com.pluxity.aiot.mic.MicStatus
+import com.pluxity.aiot.site.dto.SiteResponse
+import com.pluxity.aiot.site.dto.toSiteResponse
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "AI 마이크 응답")
+data class MicResponse(
+    @field:Schema(description = "마이크 아이디", example = "1")
+    val id: Long,
+    @field:Schema(description = "업체 장비 식별자", example = "d00c8e3364a34439183e3462e773354a1")
+    val vendorMicId: String,
+    @field:Schema(description = "마이크 명칭", example = "Example Mic (715)")
+    val name: String?,
+    @field:Schema(description = "장비 호스트", example = "192.168.0.10")
+    val host: String?,
+    @field:Schema(description = "엣지 장비 식별자")
+    val edgeId: String?,
+    @field:Schema(description = "장비 상태")
+    val status: MicStatus?,
+    @field:Schema(description = "위도", example = "37.546344")
+    val latitude: Double?,
+    @field:Schema(description = "경도", example = "126.944322")
+    val longitude: Double?,
+    @field:Schema(description = "이벤트 카테고리별 감지 기준값")
+    val thresholds: Map<String, MicThreshold>?,
+    @field:Schema(description = "소속 현장")
+    val site: SiteResponse?,
+)
+
+fun Mic.toResponse() =
+    MicResponse(
+        id = requiredId,
+        vendorMicId = vendorMicId,
+        name = name,
+        host = host,
+        edgeId = edgeId,
+        status = status,
+        latitude = latitude,
+        longitude = longitude,
+        thresholds = thresholds,
+        site = site?.toSiteResponse(),
+    )
+
+@Schema(description = "AI 마이크 이벤트 응답")
+data class MicEventResponse(
+    @field:Schema(description = "이벤트 아이디", example = "1")
+    val id: Long,
+    @field:Schema(description = "업체 이벤트 식별자", example = "23d6ec74155f4eb187b4e7301b71b5d9")
+    val eventId: String,
+    @field:Schema(description = "업체 장비 식별자")
+    val micId: String,
+    @field:Schema(description = "마이크 명칭")
+    val micName: String?,
+    @field:Schema(description = "이벤트 라벨 식별자", example = "normal_speech_female")
+    val labelId: String?,
+    @field:Schema(description = "이벤트 라벨명(한글)", example = "대화(여성)")
+    val labelNameKo: String?,
+    @field:Schema(description = "이벤트 라벨명(영문)", example = "normal speech female")
+    val labelNameEn: String?,
+    @field:Schema(description = "신뢰도", example = "0.426632")
+    val confidence: Double?,
+    @field:Schema(description = "위도")
+    val latitude: Double?,
+    @field:Schema(description = "경도")
+    val longitude: Double?,
+    @field:Schema(description = "소음 측정 원본 배열(dB)")
+    val noises: List<Double>?,
+    @field:Schema(description = "최대 소음(dB)", example = "70.66")
+    val maxNoise: Double?,
+    @field:Schema(description = "평균 소음(dB)", example = "64.39")
+    val avgNoise: Double?,
+    @field:Schema(description = "이벤트 발생 시각")
+    val occurredAt: LocalDateTime,
+)
+
+fun MicEvent.toResponse() =
+    MicEventResponse(
+        id = requiredId,
+        eventId = eventId,
+        micId = micId,
+        micName = micName,
+        labelId = labelId,
+        labelNameKo = labelNameKo,
+        labelNameEn = labelNameEn,
+        confidence = confidence,
+        latitude = latitude,
+        longitude = longitude,
+        noises = noises,
+        maxNoise = maxNoise,
+        avgNoise = avgNoise,
+        occurredAt = occurredAt,
+    )

--- a/src/main/kotlin/com/pluxity/aiot/sensor/type/SensorType.kt
+++ b/src/main/kotlin/com/pluxity/aiot/sensor/type/SensorType.kt
@@ -37,11 +37,7 @@ enum class SensorType(
         "1.0",
         "waste_fill_level",
         AbbreviationData("wfl", "쓰레기 적재 감지기"),
-        listOf(
-            DeviceProfileEnum.CONTAINER_MODULE_ID,
-            DeviceProfileEnum.ACTUAL_FILLING,
-            DeviceProfileEnum.HIGH_THRESHOLD,
-        ),
+        listOf(DeviceProfileEnum.ACTUAL_FILLING),
     ),
     FOREST_FIRE(
         4,
@@ -50,15 +46,7 @@ enum class SensorType(
         "1.0",
         "forest_fire_detection",
         AbbreviationData("ffa", "산불 감지기"),
-        listOf(
-            DeviceProfileEnum.FOREST_FIRE_DETECTION,
-            DeviceProfileEnum.TEMPERATURE,
-            DeviceProfileEnum.HUMIDITY,
-            DeviceProfileEnum.CO2,
-            DeviceProfileEnum.CO,
-            DeviceProfileEnum.TVOC,
-            DeviceProfileEnum.FIRE_CAUSE_MASK,
-        ),
+        listOf(DeviceProfileEnum.FOREST_FIRE_DETECTION),
     ),
     ODOR_MONITOR(
         5,
@@ -67,12 +55,7 @@ enum class SensorType(
         "1.0",
         "odor_monitor",
         AbbreviationData("bos", "화장실 악취 감지기"),
-        listOf(
-            DeviceProfileEnum.TEMPERATURE,
-            DeviceProfileEnum.HUMIDITY,
-            DeviceProfileEnum.NH3,
-            DeviceProfileEnum.H2S,
-        ),
+        listOf(DeviceProfileEnum.NH3, DeviceProfileEnum.H2S),
     ),
     PEOPLE_COUNTER(
         6,
@@ -96,9 +79,7 @@ enum class SensorType(
             DeviceProfileEnum.PM2_5,
             DeviceProfileEnum.PM10,
             DeviceProfileEnum.WIND_SPEED,
-            DeviceProfileEnum.WIND_DIRECTION,
             DeviceProfileEnum.UVI,
-            DeviceProfileEnum.LED_LIGHT,
         ),
     ),
     ;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -63,6 +63,9 @@ springwolf: # socket documentation ui
 eds:
   enabled: false
 
+mic:
+  enabled: false
+
 logging:
   level:
     com: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,6 +38,14 @@ eds:
   system-token: "${EDS_SYSTEM_TOKEN:}"
   keep-alive-timeout: ${EDS_KEEP_ALIVE_TIMEOUT:900}
 
+mic:
+  enabled: ${MIC_ENABLED:false}
+  base-url: ${MIC_BASE_URL:}
+  username: ${MIC_USERNAME:}
+  password: "${MIC_PASSWORD:}"
+  token-ttl-fallback: ${MIC_TOKEN_TTL_FALLBACK:3600}
+  list-page-size: ${MIC_LIST_PAGE_SIZE:100}
+
 file:
   storage-strategy: ${FILE_STORAGE_STRATEGY:s3}
   local:

--- a/src/test/kotlin/com/pluxity/aiot/dashboard/DashboardServiceKoTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/dashboard/DashboardServiceKoTest.kt
@@ -125,6 +125,10 @@ private fun createSensorStatisticsRaw(
     temperatureHumidityCount: Long,
     fireCount: Long,
     wasteFillLevelCount: Long,
+    forestFireCount: Long = 0,
+    odorMonitorCount: Long = 0,
+    peopleCounterCount: Long = 0,
+    compositeAirQualityCount: Long = 0,
 ) = SensorStatisticsRaw(
     siteId = siteId,
     siteName = siteName,
@@ -134,4 +138,8 @@ private fun createSensorStatisticsRaw(
     temperatureHumidityCount = temperatureHumidityCount,
     fireCount = fireCount,
     wasteFillLevelCount = wasteFillLevelCount,
+    forestFireCount = forestFireCount,
+    odorMonitorCount = odorMonitorCount,
+    peopleCounterCount = peopleCounterCount,
+    compositeAirQualityCount = compositeAirQualityCount,
 )

--- a/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/CompositeAirQualityProcessorTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/CompositeAirQualityProcessorTest.kt
@@ -4,7 +4,10 @@ import com.influxdb.client.WriteApi
 import com.influxdb.client.domain.WritePrecision
 import com.pluxity.aiot.data.measure.CompositeAirQuality
 import com.pluxity.aiot.event.condition.ConditionLevel
+import com.pluxity.aiot.event.condition.ConditionType
+import com.pluxity.aiot.event.condition.EventCondition
 import com.pluxity.aiot.event.condition.EventConditionRepository
+import com.pluxity.aiot.event.condition.Operator
 import com.pluxity.aiot.event.entity.EventStatus
 import com.pluxity.aiot.event.repository.EventHistoryRepository
 import com.pluxity.aiot.feature.FeatureRepository
@@ -213,6 +216,51 @@ class CompositeAirQualityProcessorTest(
                     val eventHistories = eventHistoryRepository.findByDeviceId(deviceId)
                     eventHistories shouldHaveSize 1
                     eventHistories.first().fieldKey shouldBe "PM2.5"
+                }
+            }
+        }
+
+        Given("복합 대기질 센서: 여러 항목이 동시에 조건을 충족") {
+            When("Temperature는 WARNING, PM2.5는 DANGER 조건을 충족") {
+                val deviceId = "CAQ_006"
+                val helper = helperWith(Mockito.mock(WriteApi::class.java))
+
+                val setup =
+                    helper.setupDeviceWithCondition(
+                        objectId = SensorType.COMPOSITE_AIR_QUALITY.objectId,
+                        deviceId = deviceId,
+                        eventLevel = ConditionLevel.DANGER,
+                        minValue = "35.0",
+                        maxValue = null,
+                        isBoolean = false,
+                        fieldKey = DeviceProfileEnum.PM2_5.fieldKey,
+                    )
+                eventConditionRepository.save(
+                    EventCondition(
+                        fieldKey = DeviceProfileEnum.TEMPERATURE.fieldKey,
+                        objectId = SensorType.COMPOSITE_AIR_QUALITY.objectId,
+                        isActivate = true,
+                        level = ConditionLevel.WARNING,
+                        conditionType = ConditionType.SINGLE,
+                        operator = Operator.GE,
+                        thresholdValue = 30.0,
+                        notificationEnabled = true,
+                    ),
+                )
+
+                // Temperature가 먼저 평가되지만 우선순위는 PM2.5가 높다
+                val sensorData = helper.createSensorData(temperature = 40.0, pm25 = 75)
+                helper.createProcessor().process(deviceId, setup.sensorType, setup.siteId, sensorData)
+
+                Then("우선순위가 높은 DANGER 하나만 이벤트로 기록된다") {
+                    val eventHistories = eventHistoryRepository.findByDeviceId(deviceId)
+                    eventHistories shouldHaveSize 1
+                    eventHistories.first().fieldKey shouldBe "PM2.5"
+                    eventHistories.first().eventName shouldBe "DANGER_PM2.5"
+
+                    val feature = helper.featureRepository.findByDeviceId(deviceId)
+                    feature.shouldNotBeNull()
+                    feature.eventStatus shouldBe "DANGER"
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/ForestFireProcessorTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/ForestFireProcessorTest.kt
@@ -4,10 +4,7 @@ import com.influxdb.client.WriteApi
 import com.influxdb.client.domain.WritePrecision
 import com.pluxity.aiot.data.measure.ForestFireDetection
 import com.pluxity.aiot.event.condition.ConditionLevel
-import com.pluxity.aiot.event.condition.ConditionType
-import com.pluxity.aiot.event.condition.EventCondition
 import com.pluxity.aiot.event.condition.EventConditionRepository
-import com.pluxity.aiot.event.condition.Operator
 import com.pluxity.aiot.event.entity.EventStatus
 import com.pluxity.aiot.event.repository.EventHistoryRepository
 import com.pluxity.aiot.feature.FeatureRepository
@@ -174,51 +171,6 @@ class ForestFireProcessorTest(
                     Mockito
                         .verify(writeApiMock, Mockito.times(2))
                         .writeMeasurement(Mockito.eq(WritePrecision.S), Mockito.any(ForestFireDetection::class.java))
-                }
-            }
-        }
-
-        Given("산불 감지기: 여러 항목이 동시에 조건을 충족") {
-            When("Temperature는 WARNING, FireDetection은 DANGER 조건을 충족") {
-                val deviceId = "FFA_005"
-                val helper = helperWith(Mockito.mock(WriteApi::class.java))
-
-                // FireDetection(DANGER) 조건 등록 + Temperature(WARNING) 조건 추가
-                val setup =
-                    helper.setupDeviceWithCondition(
-                        objectId = SensorType.FOREST_FIRE.objectId,
-                        deviceId = deviceId,
-                        eventLevel = ConditionLevel.DANGER,
-                        minValue = null,
-                        maxValue = null,
-                        isBoolean = true,
-                        fieldKey = DeviceProfileEnum.FOREST_FIRE_DETECTION.fieldKey,
-                    )
-                eventConditionRepository.save(
-                    EventCondition(
-                        fieldKey = DeviceProfileEnum.TEMPERATURE.fieldKey,
-                        objectId = SensorType.FOREST_FIRE.objectId,
-                        isActivate = true,
-                        level = ConditionLevel.WARNING,
-                        conditionType = ConditionType.SINGLE,
-                        operator = Operator.GE,
-                        thresholdValue = 30.0,
-                        notificationEnabled = true,
-                    ),
-                )
-
-                val sensorData = helper.createSensorData(fireDetection = true, temperature = 40.0)
-                helper.createProcessor().process(deviceId, setup.sensorType, setup.siteId, sensorData)
-
-                Then("우선순위가 높은 DANGER 하나만 이벤트로 기록된다") {
-                    val eventHistories = eventHistoryRepository.findByDeviceId(deviceId)
-                    eventHistories shouldHaveSize 1
-                    eventHistories.first().fieldKey shouldBe "FireDetection"
-                    eventHistories.first().eventName shouldBe "DANGER_FireDetection"
-
-                    val feature = helper.featureRepository.findByDeviceId(deviceId)
-                    feature.shouldNotBeNull()
-                    feature.eventStatus shouldBe "DANGER"
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/WasteFillLevelProcessorTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/WasteFillLevelProcessorTest.kt
@@ -4,7 +4,10 @@ import com.influxdb.client.WriteApi
 import com.influxdb.client.domain.WritePrecision
 import com.pluxity.aiot.data.measure.WasteFillLevel
 import com.pluxity.aiot.event.condition.ConditionLevel
+import com.pluxity.aiot.event.condition.ConditionType
+import com.pluxity.aiot.event.condition.EventCondition
 import com.pluxity.aiot.event.condition.EventConditionRepository
+import com.pluxity.aiot.event.condition.Operator
 import com.pluxity.aiot.event.entity.EventStatus
 import com.pluxity.aiot.event.repository.EventHistoryRepository
 import com.pluxity.aiot.feature.FeatureRepository
@@ -12,11 +15,13 @@ import com.pluxity.aiot.global.messaging.StompMessageSender
 import com.pluxity.aiot.sensor.type.DeviceProfileEnum
 import com.pluxity.aiot.sensor.type.SensorType
 import com.pluxity.aiot.site.SiteRepository
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
@@ -194,28 +199,78 @@ class WasteFillLevelProcessorTest(
             }
         }
 
-        Given("쓰레기 적재 감지기: 단말이 보고한 만재 기준값(HighThreshold)") {
-            When("HighThreshold에 이벤트 조건이 등록되어 있고 기준값을 초과하는 값이 수신됨") {
+        Given("쓰레기 적재 감지기: 이벤트 조건 대상이 아닌 항목") {
+            When("HighThreshold로 이벤트 조건을 등록하려 함") {
+                Then("SensorType의 프로필에 없어 저장이 거부된다") {
+                    val exception =
+                        shouldThrowAny {
+                            EventCondition(
+                                fieldKey = DeviceProfileEnum.HIGH_THRESHOLD.fieldKey,
+                                objectId = SensorType.WASTE_FILL_LEVEL.objectId,
+                                isActivate = true,
+                                level = ConditionLevel.WARNING,
+                                conditionType = ConditionType.SINGLE,
+                                operator = Operator.GE,
+                                thresholdValue = 60.0,
+                                notificationEnabled = true,
+                            )
+                        }
+                    exception.message shouldContain "HighThreshold"
+                }
+            }
+
+            When("ContainerModuleId로 이벤트 조건을 등록하려 함") {
+                Then("마찬가지로 저장이 거부된다") {
+                    shouldThrowAny {
+                        EventCondition(
+                            fieldKey = DeviceProfileEnum.CONTAINER_MODULE_ID.fieldKey,
+                            objectId = SensorType.WASTE_FILL_LEVEL.objectId,
+                            isActivate = true,
+                            level = ConditionLevel.WARNING,
+                            conditionType = ConditionType.SINGLE,
+                            operator = Operator.GE,
+                            thresholdValue = 1.0,
+                            notificationEnabled = true,
+                        )
+                    }
+                }
+            }
+
+            When("HighThreshold가 담긴 데이터가 수신됨") {
                 val deviceId = "WFL_005"
+                val writeApiMock = Mockito.mock(WriteApi::class.java)
+                val localHelper =
+                    WasteFillLevelProcessorTestHelper(
+                        siteRepository,
+                        featureRepository,
+                        eventHistoryRepository,
+                        messageSenderMock,
+                        writeApiMock,
+                        eventConditionRepository,
+                    )
 
                 val setup =
-                    helper.setupDeviceWithCondition(
+                    localHelper.setupDeviceWithCondition(
                         objectId = SensorType.WASTE_FILL_LEVEL.objectId,
                         deviceId = deviceId,
                         eventLevel = ConditionLevel.WARNING,
                         minValue = "60.0",
                         maxValue = null,
                         isBoolean = false,
-                        fieldKey = DeviceProfileEnum.HIGH_THRESHOLD.fieldKey,
+                        fieldKey = DeviceProfileEnum.ACTUAL_FILLING.fieldKey,
                     )
 
-                val sensorData = helper.createSensorData(actualFilling = 30, highThreshold = 80)
-                val processor = helper.createProcessor()
+                val sensorData = localHelper.createSensorData(actualFilling = 30, highThreshold = 80)
+                localHelper.createProcessor().process(deviceId, setup.sensorType, setup.siteId, sensorData)
 
-                processor.process(deviceId, setup.sensorType, setup.siteId, sensorData)
-
-                Then("기준값 자체로는 이벤트가 발생하지 않는다") {
+                Then("이벤트는 발생하지 않지만 값은 InfluxDB에 적재된다") {
                     eventHistoryRepository.findByDeviceId(deviceId) shouldHaveSize 0
+
+                    val captor = ArgumentCaptor.forClass(WasteFillLevel::class.java)
+                    Mockito
+                        .verify(writeApiMock, Mockito.times(2))
+                        .writeMeasurement(Mockito.eq(WritePrecision.S), captor.capture())
+                    captor.allValues.map { it.fieldKey } shouldBe listOf("ActualFilling", "HighThreshold")
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/WasteFillLevelProcessorTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/data/subscription/processor/impl/WasteFillLevelProcessorTest.kt
@@ -274,4 +274,55 @@ class WasteFillLevelProcessorTest(
                 }
             }
         }
+
+        Given("쓰레기 적재 감지기: 조건 대상 값이 없는 페이로드") {
+            When("경보 발생 후 ActualFilling이 빠진 페이로드가 수신됨") {
+                val deviceId = "WFL_006"
+                val helper2 =
+                    WasteFillLevelProcessorTestHelper(
+                        siteRepository,
+                        featureRepository,
+                        eventHistoryRepository,
+                        messageSenderMock,
+                        Mockito.mock(WriteApi::class.java),
+                        eventConditionRepository,
+                    )
+
+                val setup =
+                    helper2.setupDeviceWithCondition(
+                        objectId = SensorType.WASTE_FILL_LEVEL.objectId,
+                        deviceId = deviceId,
+                        eventLevel = ConditionLevel.WARNING,
+                        minValue = "60.0",
+                        maxValue = null,
+                        isBoolean = false,
+                        fieldKey = DeviceProfileEnum.ACTUAL_FILLING.fieldKey,
+                    )
+
+                val processor = helper2.createProcessor()
+                processor.process(
+                    deviceId,
+                    setup.sensorType,
+                    setup.siteId,
+                    helper2.createSensorData(actualFilling = 70),
+                )
+
+                // ProjectConfig가 InstancePerLeaf라 Then이 여러 개면 When 본문이 재실행된다.
+                // Feature를 insert하는 컨테이너이므로 검증은 하나의 Then에 모은다
+                Then("판단 근거가 없으므로 경보 상태가 유지된다") {
+                    helper2.featureRepository.findByDeviceId(deviceId)?.eventStatus shouldBe "WARNING"
+
+                    processor.process(
+                        deviceId,
+                        setup.sensorType,
+                        setup.siteId,
+                        helper2.createSensorData(containerModuleId = 1, highThreshold = 80),
+                    )
+
+                    val feature = helper2.featureRepository.findByDeviceId(deviceId)
+                    feature.shouldNotBeNull()
+                    feature.eventStatus shouldBe "WARNING"
+                }
+            }
+        }
     })

--- a/src/test/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycleKoTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/global/lifecycle/RetryingLifecycleKoTest.kt
@@ -1,0 +1,110 @@
+package com.pluxity.aiot.global.lifecycle
+
+import io.kotest.assertions.timing.eventually
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * 지정한 횟수만큼 실패한 뒤 성공하는 초기화를 흉내낸다.
+ */
+private class FakeLifecycle(
+    private val failCount: Int,
+    private val onInitialize: () -> Unit = {},
+) : RetryingLifecycle("테스트", initialRetryDelaySeconds = 1, maxRetryDelaySeconds = 2) {
+    val initializeCalls = AtomicInteger()
+    val shutdownCalls = AtomicInteger()
+
+    override fun initialize() {
+        val call = initializeCalls.getAndIncrement()
+        onInitialize()
+        if (call < failCount) {
+            throw IllegalStateException("초기화 실패")
+        }
+    }
+
+    override fun shutdown() {
+        shutdownCalls.incrementAndGet()
+    }
+}
+
+class RetryingLifecycleKoTest :
+    BehaviorSpec({
+
+        Given("외부 연동 기동") {
+            When("초기화가 처음부터 성공") {
+                val lifecycle = FakeLifecycle(failCount = 0)
+                lifecycle.start()
+
+                Then("재시도 없이 초기화가 완료된다") {
+                    lifecycle.isInitialized shouldBe true
+                    lifecycle.isRunning shouldBe true
+                    lifecycle.initializeCalls.get() shouldBe 1
+                }
+
+                lifecycle.stop()
+            }
+
+            When("초기화가 두 번 실패한 뒤 성공") {
+                val lifecycle = FakeLifecycle(failCount = 2)
+                lifecycle.start()
+
+                Then("초기화 전에도 isRunning은 true라 Spring이 종료 시 stop을 호출할 수 있다") {
+                    lifecycle.isRunning shouldBe true
+                    lifecycle.isInitialized shouldBe false
+                }
+
+                Then("재시도가 이어져 결국 초기화가 완료된다") {
+                    eventually(10.seconds) {
+                        lifecycle.isInitialized shouldBe true
+                    }
+                    lifecycle.initializeCalls.get() shouldBe 3
+                }
+
+                lifecycle.stop()
+            }
+
+            When("초기화가 계속 실패하는 중에 stop이 호출됨") {
+                val lifecycle = FakeLifecycle(failCount = Int.MAX_VALUE)
+                lifecycle.start()
+                val callsAtStop = lifecycle.initializeCalls.get()
+                lifecycle.stop()
+
+                Then("shutdown이 호출되고 재시도가 멈춘다") {
+                    lifecycle.shutdownCalls.get() shouldBe 1
+                    lifecycle.isRunning shouldBe false
+                    lifecycle.isInitialized shouldBe false
+
+                    // 재시도 간격(1초)을 넉넉히 넘겨도 더 이상 호출되지 않는다
+                    Thread.sleep(2500)
+                    lifecycle.initializeCalls.get() shouldBe callsAtStop
+                }
+            }
+
+            When("초기화가 진행되는 도중에 stop이 호출됨") {
+                val initializeStarted = CountDownLatch(1)
+                val stopCalled = CountDownLatch(1)
+                val lifecycle =
+                    FakeLifecycle(failCount = 0) {
+                        initializeStarted.countDown()
+                        // stop()이 먼저 실행되도록 초기화를 붙잡아 둔다
+                        stopCalled.await(5, TimeUnit.SECONDS)
+                    }
+
+                val starter = Thread { lifecycle.start() }.apply { start() }
+                initializeStarted.await(5, TimeUnit.SECONDS)
+                lifecycle.stop()
+                stopCalled.countDown()
+                starter.join(5_000)
+
+                Then("뒤늦게 끝난 초기화가 되살린 자원을 다시 정리한다") {
+                    lifecycle.isRunning shouldBe false
+                    lifecycle.isInitialized shouldBe false
+                    lifecycle.shutdownCalls.get() shouldBe 2
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/aiot/mic/MicEventServiceKoTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/mic/MicEventServiceKoTest.kt
@@ -1,0 +1,141 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.mic.dto.MicEventData
+import com.pluxity.aiot.mic.dto.MicEventLabel
+import com.pluxity.aiot.mic.dto.MicEventLabelName
+import com.pluxity.aiot.mic.dto.MicEventSource
+import com.pluxity.aiot.mic.dto.MicLocation
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDateTime
+
+private fun eventData(
+    id: String = "23d6ec74155f4eb187b4e7301b71b5d9",
+    micId: String? = "d00c8e3364a34439183e3462e773354a1",
+    createdAt: String? = "2024-01-01T00:00:00Z",
+    noises: List<Double>? = listOf(66.99, 65.28, 68.21),
+) = MicEventData(
+    id = id,
+    label =
+        MicEventLabel(
+            id = "normal_speech_female",
+            name = MicEventLabelName(ko = "대화(여성)", en = "normal speech female"),
+        ),
+    confidence = 0.426632,
+    mic =
+        micId?.let {
+            MicEventSource(
+                id = it,
+                name = "Example Mic (715)",
+                location = MicLocation(37.546344, 126.944322),
+            )
+        },
+    createdAt = createdAt,
+    noises = noises,
+)
+
+class MicEventServiceKoTest :
+    BehaviorSpec({
+
+        Given("AI 마이크 이벤트 저장") {
+            When("정상 이벤트가 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+                every { repository.existsByEventId(any()) } returns false
+                val saved = slot<MicEvent>()
+                every { repository.save(capture(saved)) } answers { saved.captured }
+
+                MicEventService(repository).saveEvent(eventData())
+
+                Then("라벨·신뢰도·좌표가 저장된다") {
+                    saved.captured.eventId shouldBe "23d6ec74155f4eb187b4e7301b71b5d9"
+                    saved.captured.micId shouldBe "d00c8e3364a34439183e3462e773354a1"
+                    saved.captured.micName shouldBe "Example Mic (715)"
+                    saved.captured.labelId shouldBe "normal_speech_female"
+                    saved.captured.labelNameKo shouldBe "대화(여성)"
+                    saved.captured.labelNameEn shouldBe "normal speech female"
+                    saved.captured.confidence shouldBe 0.426632
+                    saved.captured.latitude shouldBe 37.546344
+                    saved.captured.longitude shouldBe 126.944322
+                }
+
+                Then("noises 원본과 최대·평균 요약이 함께 저장된다") {
+                    saved.captured.noises shouldBe listOf(66.99, 65.28, 68.21)
+                    saved.captured.maxNoise shouldBe 68.21
+                    saved.captured.avgNoise!! shouldBe (66.826 plusOrMinus 0.001)
+                }
+
+                Then("created_at이 KST로 변환되어 저장된다") {
+                    saved.captured.occurredAt shouldBe LocalDateTime.of(2024, 1, 1, 9, 0, 0)
+                }
+            }
+
+            When("created_at이 없는 이벤트가 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+                every { repository.existsByEventId(any()) } returns false
+                val saved = slot<MicEvent>()
+                every { repository.save(capture(saved)) } answers { saved.captured }
+
+                val before = LocalDateTime.now()
+                MicEventService(repository).saveEvent(eventData(createdAt = null))
+
+                Then("수신 시각으로 대체된다") {
+                    (saved.captured.occurredAt >= before) shouldBe true
+                }
+            }
+
+            When("created_at 형식이 잘못된 이벤트가 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+                every { repository.existsByEventId(any()) } returns false
+                val saved = slot<MicEvent>()
+                every { repository.save(capture(saved)) } answers { saved.captured }
+
+                val before = LocalDateTime.now()
+                MicEventService(repository).saveEvent(eventData(createdAt = "not-a-date"))
+
+                Then("예외 없이 수신 시각으로 대체된다") {
+                    (saved.captured.occurredAt >= before) shouldBe true
+                }
+            }
+
+            When("이미 저장된 이벤트 id가 다시 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+                every { repository.existsByEventId(any()) } returns true
+
+                MicEventService(repository).saveEvent(eventData())
+
+                Then("중복 저장하지 않는다") {
+                    verify(exactly = 0) { repository.save(any()) }
+                }
+            }
+
+            When("마이크 정보가 없는 이벤트가 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+
+                MicEventService(repository).saveEvent(eventData(micId = null))
+
+                Then("저장하지 않고 무시한다") {
+                    verify(exactly = 0) { repository.save(any()) }
+                    verify(exactly = 0) { repository.existsByEventId(any()) }
+                }
+            }
+
+            When("noises가 비어 있는 이벤트가 수신됨") {
+                val repository: MicEventRepository = mockk(relaxed = true)
+                every { repository.existsByEventId(any()) } returns false
+                val saved = slot<MicEvent>()
+                every { repository.save(capture(saved)) } answers { saved.captured }
+
+                MicEventService(repository).saveEvent(eventData(noises = emptyList()))
+
+                Then("평균 계산에서 NaN이 나오지 않는다") {
+                    saved.captured.maxNoise shouldBe null
+                    saved.captured.avgNoise shouldBe null
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/aiot/mic/MicServiceKoTest.kt
+++ b/src/test/kotlin/com/pluxity/aiot/mic/MicServiceKoTest.kt
@@ -1,0 +1,118 @@
+package com.pluxity.aiot.mic
+
+import com.pluxity.aiot.base.entity.withId
+import com.pluxity.aiot.fixture.SiteFixture
+import com.pluxity.aiot.mic.dto.MicInfo
+import com.pluxity.aiot.mic.dto.MicLocation
+import com.pluxity.aiot.mic.dto.MicThreshold
+import com.pluxity.aiot.site.SiteRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+
+private fun micInfo(
+    id: String = "mic-1",
+    name: String? = "Example Mic (715)",
+    host: String? = "192.168.0.10",
+    edgeId: String? = "edge-1",
+    status: String? = "active",
+    latitude: Double? = 37.05,
+    longitude: Double? = 127.05,
+    thresholds: Map<String, MicThreshold>? = mapOf("breathing_heavily" to MicThreshold(65.0, 0.8)),
+) = MicInfo(
+    id = id,
+    name = name,
+    host = host,
+    edgeId = edgeId,
+    status = status,
+    thresholds = thresholds,
+    location = if (latitude != null && longitude != null) MicLocation(latitude, longitude) else null,
+)
+
+class MicServiceKoTest :
+    BehaviorSpec({
+
+        Given("AI 마이크 동기화") {
+            When("기존에 없던 마이크가 내려옴") {
+                val micRepository: MicRepository = mockk(relaxed = true)
+                val siteRepository: SiteRepository = mockk()
+                val site = SiteFixture.create(id = 1L)
+                every { micRepository.findAllWithSite() } returns emptyList()
+                every { siteRepository.findFirstByPointInPolygon(any(), any()) } returns site
+
+                val saved = slot<Mic>()
+                every { micRepository.save(capture(saved)) } answers { saved.captured }
+
+                MicService(micRepository, siteRepository).sync(listOf(micInfo()))
+
+                Then("마이크가 신규 저장되고 좌표로 현장이 매핑된다") {
+                    saved.captured.vendorMicId shouldBe "mic-1"
+                    saved.captured.name shouldBe "Example Mic (715)"
+                    saved.captured.host shouldBe "192.168.0.10"
+                    saved.captured.edgeId shouldBe "edge-1"
+                    saved.captured.status shouldBe MicStatus.ACTIVE
+                    saved.captured.latitude shouldBe 37.05
+                    saved.captured.longitude shouldBe 127.05
+                    saved.captured.geom.shouldNotBeNull()
+                    saved.captured.site shouldBe site
+                    saved.captured.thresholds
+                        ?.get("breathing_heavily")
+                        ?.soundLevelGe shouldBe 65.0
+                }
+            }
+
+            When("이미 있는 마이크의 정보가 바뀜") {
+                val micRepository: MicRepository = mockk(relaxed = true)
+                val siteRepository: SiteRepository = mockk()
+                val existing =
+                    Mic(vendorMicId = "mic-1", name = "예전 이름", status = MicStatus.ACTIVE).withId(10L)
+                every { micRepository.findAllWithSite() } returns listOf(existing)
+                every { siteRepository.findFirstByPointInPolygon(any(), any()) } returns null
+
+                MicService(micRepository, siteRepository).sync(listOf(micInfo(name = "새 이름", status = "inactive")))
+
+                Then("기존 엔티티가 갱신되고 신규 저장은 일어나지 않는다") {
+                    existing.name shouldBe "새 이름"
+                    existing.status shouldBe MicStatus.INACTIVE
+                    verify(exactly = 0) { micRepository.save(any()) }
+                }
+            }
+
+            When("기존 마이크가 업체 목록에서 사라짐") {
+                val micRepository: MicRepository = mockk(relaxed = true)
+                val siteRepository: SiteRepository = mockk()
+                val existing = Mic(vendorMicId = "mic-gone", status = MicStatus.ACTIVE).withId(11L)
+                every { micRepository.findAllWithSite() } returns listOf(existing)
+                every { siteRepository.findFirstByPointInPolygon(any(), any()) } returns null
+
+                MicService(micRepository, siteRepository).sync(emptyList())
+
+                Then("DISCONNECTED로 표시된다") {
+                    existing.status shouldBe MicStatus.DISCONNECTED
+                }
+            }
+
+            When("좌표가 없는 마이크가 내려옴") {
+                val micRepository: MicRepository = mockk(relaxed = true)
+                val siteRepository: SiteRepository = mockk()
+                every { micRepository.findAllWithSite() } returns emptyList()
+
+                val saved = slot<Mic>()
+                every { micRepository.save(capture(saved)) } answers { saved.captured }
+
+                MicService(micRepository, siteRepository)
+                    .sync(listOf(micInfo(latitude = null, longitude = null)))
+
+                Then("위치와 현장이 비어 있고 현장 조회를 시도하지 않는다") {
+                    saved.captured.latitude shouldBe null
+                    saved.captured.geom shouldBe null
+                    saved.captured.site shouldBe null
+                    verify(exactly = 0) { siteRepository.findFirstByPointInPolygon(any(), any()) }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
Closes #34

## Summary

인텔리빅스 AI Sound Box(마이크) 장비를 연동하고 실시간 이벤트를 수신·저장·조회합니다. 기존 `eds`(AI CCTV) 연동 구조를 따르되, 업체 서버가 IP는 같지만 포트와 인증 방식이 달라 별도 패키지로 분리했습니다.

### `mic` 패키지 (신규)

전체에 `@ConditionalOnProperty("mic.enabled")`가 걸려 있어 설정으로 on/off 됩니다.

- **`MicClient`** — `/auth/token` 로그인 후 `accessToken`·`expiresIn` 보관, `/mics` 페이지 순회. 401이면 재로그인 후 1회 재시도하며, 재로그인·재요청 실패도 도메인 예외로 변환
- **`MicTokenScheduler`** — 업체에 토큰 갱신 엔드포인트가 없어 `expires_in / 2` 주기로 재로그인
- **`MicWebSocketClient`** — `/ws/events`에 `Authorization: Bearer` 헤더로 연결. `Mono.defer`로 감싸 재연결마다 갱신된 토큰을 다시 읽습니다(`eds`는 이 처리가 없어 재로그인 후 재연결이 영구 실패하는 결함이 설계 문서에 기록돼 있습니다). 5초 재시도 + 최대 2분 백오프
- **`Mic` 엔티티** — `Cctv` 패턴. 좌표로 `Site` 자동 매핑, 업체 목록에서 사라진 장비는 `DISCONNECTED`
- **`MicEvent` 엔티티** — `eds_event`와 식별자 타입·필수 컬럼·생애주기가 달라 별도 테이블. `eventId` 중복 차단, `created_at`을 KST로 변환(없거나 파싱 실패 시 수신 시각)
- `noises`/`thresholds`는 `@JdbcTypeCode(SqlTypes.JSON)`으로 보관하고 최대·평균 소음은 요약 컬럼으로 분리
- **API** — `GET /mics`, `GET /mics/events`(micId·기간 필터), `POST /mics/sync`. `eds`와 동일하게 저장·조회만 하고 STOMP 실시간 푸시는 연결하지 않았습니다

### `RetryingLifecycle` (신규, `eds`에도 적용)

Spring은 `SmartLifecycle.start()`를 다시 호출하지 않아, 업체 서버가 늦게 뜨거나 일시적으로 응답하지 않으면 재시작 전까지 연동이 멈춘 채로 남았습니다. 특히 동기화만 실패하면 스케줄러는 떠 있고 WebSocket은 연결되지 않아 이벤트 수집이 중단됐습니다.

- 초기화 실패 시 10초부터 두 배씩 최대 5분 간격으로 **전체 시퀀스**를 재시도
- `isRunning`은 라이프사이클 활성 여부를, 초기화 성공 여부는 `isInitialized`를 반환. `DefaultLifecycleProcessor`가 `isRunning=true`인 빈에만 `stop()`을 호출하므로, 재시도 대기 중 종료될 때 예약된 재시도가 취소되지 않던 문제를 막습니다
- 상태 전이를 락으로 직렬화하고, 종료 중 뒤늦게 끝난 초기화가 자원을 되살리는 경합을 막습니다

### 이벤트 조건 정리

`deviceProfiles`가 `EventCondition`의 유효 fieldKey 목록으로 쓰이는데, 식별 값이나 설정값까지 포함돼 있어 조건을 저장해도 영원히 발화하지 않는 항목이 있었습니다. 조건 대상만 남기고 적재·조회는 전 항목을 유지합니다.

| 센서 | 조건 대상 | 조회만 가능 |
|---|---|---|
| 쓰레기 적재 | ActualFilling | ContainerModuleId, HighThreshold |
| 산불 감지기 | FireDetection | Temperature, Humidity, CO2, CO, TVOC, FireCauseMask |
| 화장실 악취 | NH3, H2S | Temperature, Humidity |
| 복합 대기질 | Temperature, Humidity, PM2.5, PM10, WindSpeed, UVI | WindDirection, LED Light |

또한 조건 대상 항목이 하나도 오지 않은 페이로드에서는 상태를 그대로 둡니다. 기존에는 판단 근거 없이 `NORMAL`로 경보가 해제됐습니다. 평가는 했으나 아무 조건도 충족하지 않은 경우(정상적인 경보 해제)와는 구분합니다.

### 그 외 수정

- **스케줄러 스레드 누수** — `MicTokenScheduler`, `EdsKeepAliveScheduler`의 `stop()`이 예약 작업만 취소하고 실행기는 남겨둬 비데몬 스레드가 누수됐습니다. 데몬 팩토리로 바꾸고 `shutdownNow()`까지 수행하며, `start()`가 새 실행기를 만들어 재시작에 안전합니다
- **시계열 집계** — `aggregateWindow`가 버킷마다 `mean`을 적용해 `FireDetection`(Boolean)과 `FireCauseMask`(비트 마스크)가 소수로 뭉개졌습니다. `WindDirection`(방위각), `LED Light`(상태값), `ContainerModuleId`(식별 값)도 평균이 성립하지 않아 시계열 조회 대상에서 제외했습니다. 집계를 거치지 않는 최신값 조회는 전 항목을 그대로 반환합니다
- **대시보드** — `totalSensors`에는 포함되지만 내역에는 없던 산불·악취·피플카운터·복합대기질 4종의 count를 추가했습니다

## Test plan

`./gradlew spotlessCheck test` — **202개 전부 통과**

- `MicServiceKoTest` — 신규 저장·현장 자동 매핑 / 기존 갱신 / 목록 이탈 시 DISCONNECTED / 좌표 없으면 현장 조회 생략
- `MicEventServiceKoTest` — 필드 매핑 / noises 요약 / `created_at` KST 변환 / null·잘못된 형식 폴백 / 중복 차단 / 마이크 정보 없으면 무시 / 빈 배열 NaN 방지
- `RetryingLifecycleKoTest` — 즉시 성공 / 두 번 실패 후 성공 / 재시도 중 stop / 초기화 진행 중 stop 시 자원 재정리
- 조건 대상이 아닌 fieldKey로 조건 저장이 거부되는지, 조건 대상 값이 없는 페이로드에서 경보가 유지되는지

`MicLifecycle`이 실제 업체 서버에 로그인을 시도하므로 `@SpringBootTest` 대신 mockk 단위 테스트로 작성했습니다.

## 확인 필요

- **실제 연동 미검증** — 업체 API를 호출하지 않아 응답 구조가 스펙과 다르면 DTO 조정이 필요합니다. `mic.enabled=true` + `base-url: http://115.93.67.42:38100/api/v1`로 로컬 기동하면 로그인·동기화·WS 연결이 로그로 확인됩니다
- **`/ws/events` 경로 위치** — `/api/v1` 아래인지 루트인지에 따라 `MicWebSocketClient.buildUri()` 수정이 필요할 수 있습니다
- **프론트 영향** — `sensorTypeStatus`에 필드 4개 추가, 시계열 응답에서 `FireDetection`·`FireCauseMask`·`WindDirection`·`LED Light`·`ContainerModuleId` 제외
- **`jsonb` 첫 도입** — `@JdbcTypeCode(SqlTypes.JSON)`은 Hibernate 표준이지만 이 저장소에서는 처음입니다. `ddl-auto: update`라 컬럼은 자동 생성됩니다
- 스케줄러를 `ThreadPoolTaskScheduler` 빈으로 통합하는 건 가상 스레드 작업(`docs/specs/2026-08-25-virtual-threads-design.md`)에서 함께 정리하는 편이 낫다고 보고 미뤘습니다

https://claude.ai/code/session_01TuU6kHPsuYbfRjSkuMTkWW