### PR TITLE
fix: AI 마이크 API 경로에 /api/v1 접두사 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/aiot/global/properties/MicProperties.kt
+++ b/src/main/kotlin/com/pluxity/aiot/global/properties/MicProperties.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "mic")
 data class MicProperties(
     val enabled: Boolean = false,
+    /** 호스트까지만 설정한다. /api/v1 접두사는 MicClient가 붙인다 */
     val baseUrl: String = "",
     val username: String = "",
     val password: String = "",

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicClient.kt
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 
 private val log = KotlinLogging.logger {}
 
@@ -41,10 +42,10 @@ class MicClient(
         val result =
             client
                 .post()
-                .uri("/auth/token")
+                .uri("$API_PREFIX/auth/token")
                 .bodyValue(MicLoginRequest(micProperties.username, micProperties.password))
                 .retrieve()
-                .bodyToMono(MicLoginResult::class.java)
+                .bodyToMono<MicLoginResult>()
                 .block()
                 ?: throw CustomException(ErrorCode.MIC_LOGIN_FAILED, "응답 없음")
 
@@ -78,7 +79,7 @@ class MicClient(
                 .get()
                 .uri {
                     it
-                        .path("/mics")
+                        .path("$API_PREFIX/mics")
                         .queryParam("page", page)
                         .queryParam("size", size)
                         .build()
@@ -98,7 +99,7 @@ class MicClient(
             block()
         } catch (e: WebClientResponseException) {
             if (e.statusCode != HttpStatus.UNAUTHORIZED) {
-                throw CustomException(ErrorCode.MIC_API_ERROR, e.message ?: "알 수 없는 오류")
+                throw CustomException(ErrorCode.MIC_API_ERROR, e.message)
             }
             log.warn { "AI 마이크 API 401, 재로그인 후 재시도" }
             retryAfterLogin(block)
@@ -116,5 +117,10 @@ class MicClient(
         } catch (e: Exception) {
             throw CustomException(ErrorCode.MIC_API_ERROR, e.message ?: "알 수 없는 오류")
         }
+    }
+
+    companion object {
+        /** 업체 API는 모든 엔드포인트가 이 접두사 아래에 있다. baseUrl에는 호스트만 설정한다 */
+        const val API_PREFIX = "/api/v1"
     }
 }

--- a/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
+++ b/src/main/kotlin/com/pluxity/aiot/mic/MicWebSocketClient.kt
@@ -92,6 +92,6 @@ class MicWebSocketClient(
 
     companion object {
         private val HTTP_SCHEME_REGEX = Regex("^http")
-        private const val WS_EVENTS_PATH = "/ws/events"
+        private const val WS_EVENTS_PATH = "${MicClient.API_PREFIX}/ws/events"
     }
 }


### PR DESCRIPTION
## Summary

업체 API는 로그인·목록·이벤트 WebSocket이 모두 `/api/v1` 아래에 있는데, `MicClient`가 접두사 없이 호출하고 있었습니다.

`baseUrl`에 경로를 넣으면 Spring `DefaultUriBuilderFactory`의 URI 병합 규칙에 의존하게 되므로, 기존 `EdsClient`와 동일하게 **baseUrl은 호스트까지만 두고 요청 경로에 접두사를 명시**했습니다.

- `MicClient.API_PREFIX` 상수를 두고 `/auth/token`, `/mics`에 적용
- `MicWebSocketClient`도 같은 상수를 재사용해 `/api/v1/ws/events`로 연결
- `bodyToMono`를 reified 확장으로 정리하고 예외 메시지 처리를 단순화

결과 URL:

| | URL |
|---|---|
| 로그인 | `{baseUrl}/api/v1/auth/token` |
| 마이크 목록 | `{baseUrl}/api/v1/mics?page=&size=` |
| 이벤트 WS | `ws://{host}/api/v1/ws/events` |

## Test plan

`./gradlew spotlessCheck test` — 202개 전부 통과

경로 상수 변경이라 신규 테스트는 추가하지 않았습니다. 실제 검증은 `mic.enabled=true`로 기동해 로그인·동기화·WS 연결 로그로 확인해야 합니다.

## 배포 시 확인

**`MIC_BASE_URL` 설정값에서 `/api/v1`을 빼야 합니다.** `http://115.93.67.42:38100` 형태로 호스트까지만 넣습니다.

https://claude.ai/code/session_01TuU6kHPsuYbfRjSkuMTkWW